### PR TITLE
Add install details for from-scratch installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 To run this:
 ===
 
+- Install the requirements for the requirements: `apt-get install python-dev libxslt-dev libxml2-dev libmysqlclient-dev python python-pip`
 - install the python libs in requirements.txt (`pip install -r requirements.txt`)
 - make sure that the environment variable SERVER_ENV is set (to DEV). This loads the config file you need.
 - rename instance/config-sample.py to instance/config.py and change values inside it


### PR DESCRIPTION
Possibly a little over-verbose but adding a line to install for a completely blank Debian 7 machine. 
